### PR TITLE
Make selection background rectangular over selection

### DIFF
--- a/src/css/selections.less
+++ b/src/css/selections.less
@@ -15,6 +15,7 @@
       background: Highlight !important;
       color: HighlightText;
       border-color: HighlightText;
+      display: inline-block;
     }
 
     .mq-matrixed {


### PR DESCRIPTION
This makes the backgrounds of selections rectangular over the whole selection for both static and editable math.
